### PR TITLE
Render custom configs that don't have a default template

### DIFF
--- a/image/presto-entrypoint.py
+++ b/image/presto-entrypoint.py
@@ -117,13 +117,17 @@ def bootstrap(arguments: dict):
             custom_directory=TEMPLATE_CUSTOM_DIRECTORY,
             **arguments
         )
-    ## Render custom configs that don't have a default template
+    # Render custom configs that don't have a default template
+    default_directory = Path(TEMPLATE_DEFAULT_DIRECTORY)
     default_config_names = {
-        path.stem for path in Path(TEMPLATE_DEFAULT_DIRECTORY).glob("*.properties.jinja2")}
-    for custom_config_path in Path(TEMPLATE_CUSTOM_DIRECTORY).glob("*.properties"):
-        if custom_config_path.name not in default_config_names:
+        path.stem
+        for path in default_directory.glob("*.properties.jinja2")
+    }
+    custom_directory = Path(TEMPLATE_CUSTOM_DIRECTORY)
+    for path in custom_directory.glob("*.properties"):
+        if path.name not in default_config_names:
             render(
-                template_name=str(custom_config_path.relative_to(Path(TEMPLATE_DIRECTORY))),
+                template_name=str(path.relative_to(Path(TEMPLATE_DIRECTORY))),
                 output_directory=CONFIGS_DIRECTORY,
                 **arguments
             )

--- a/image/presto-entrypoint.py
+++ b/image/presto-entrypoint.py
@@ -3,6 +3,7 @@
 import argparse
 import glob
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import textwrap
@@ -116,6 +117,16 @@ def bootstrap(arguments: dict):
             custom_directory=TEMPLATE_CUSTOM_DIRECTORY,
             **arguments
         )
+    ## Render custom configs that don't have a default template
+    default_config_names = {
+        path.stem for path in Path(TEMPLATE_DEFAULT_DIRECTORY).glob("*.properties.jinja2")}
+    for custom_config_path in Path(TEMPLATE_CUSTOM_DIRECTORY).glob("*.properties"):
+        if custom_config_path.name not in default_config_names:
+            render(
+                template_name=str(custom_config_path.relative_to(Path(TEMPLATE_DIRECTORY))),
+                output_directory=CONFIGS_DIRECTORY,
+                **arguments
+            )
 
     print('\n--- Boostrapping Catalog Files ---')
     glob_path = os.path.join(TEMPLATE_CATALOG_DIRECTORY, '*.properties')


### PR DESCRIPTION
If we have s.th. like
```yaml
coordinatorConfigs:
  access-control.properties: |
    access-control.name=read-only
```
in our helm values, it's not added to the configuration right now, because there's no matching default template in the docker image.

This is an attempt to allow rendering of custom config files/templates, similar to how it's done with catalogs already.